### PR TITLE
Solucionando error del registro: no tomaba el .value de password

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -107,7 +107,7 @@ h2{
     }
     #containerForm{
         justify-content: center;
-        grid-column: 5 / 12;
+        grid-column: 6 / 11;
         grid-row: 2 / 2;
     }
     img{
@@ -115,7 +115,7 @@ h2{
         Margin: 0rem;
         border-radius: 0.5rem; 
         width: 25rem;
-        height: 25rem;
+        height: 20rem;
         margin: 0.5rem;
     }    
     .center{
@@ -141,7 +141,7 @@ h2{
         Margin: 0rem;
         border-radius: 0.5rem; 
         width: 18rem;
-        height: 18rem;
+        height: 15rem;
         margin: 0.5rem;
     }    
     .center{
@@ -166,7 +166,7 @@ h2{
         Margin: 0rem;
         border-radius: 0.5rem; 
         width: 15rem;
-        height: 15rem;
+        height: 12rem;
         margin: 0.5rem;
     }
     .center{
@@ -191,7 +191,7 @@ h2{
         Margin: 0rem;
         border-radius: 0.5rem; 
         width: 10rem;
-        height: 10rem;
+        height: 8rem;
         /* margin: 0.5rem; */
     }
     .center{

--- a/src/assets/views/screenAuth.js
+++ b/src/assets/views/screenAuth.js
@@ -38,16 +38,16 @@ export const screenAuth = () => {
     let errPassRepeat = "Las contraseñas ingresadas no coinciden";
 
     let emailCheckin = document.getElementById("email").value;
-    let passwordCheckin = document.getElementById("password").value;
-    let passwordRepeat= document.getElementById("password_repeat").value; 
+    let passwordCheckin = document.getElementById("password");
+    let passwordRepeat= document.getElementById("password_repeat"); 
 
     let resultValidateEmailCheckin = validateEmailCheckin(emailCheckin);
-    let resultValidatePasswordCheckin = validatePasswordCheckin(passwordCheckin);
-    let resultValidatePasswordRepeat = validatePasswordRepeat(passwordRepeat);
-    
+    let resultValidatePasswordCheckin = validatePasswordCheckin(passwordCheckin.value);
+    let resultValidatePasswordRepeat = validatePasswordRepeat(passwordRepeat.value, passwordCheckin.value);
+
 
     if (resultValidateEmailCheckin === true && resultValidatePasswordCheckin === true && resultValidatePasswordRepeat === true) {
-      checkin(emailCheckin, passwordCheckin);
+      checkin(emailCheckin, passwordCheckin.value);
     }
     if (resultValidateEmailCheckin === false) {
       document.getElementById("error-email-checkin").innerHTML = `${errMailCheckin}`;
@@ -58,8 +58,8 @@ export const screenAuth = () => {
     if (resultValidatePasswordRepeat === false) {
       document.getElementById("error-password-repeat").innerHTML = `${errPassRepeat}`;
       //No funciona el limpiado de campos. si las contraseñas no coinciden hay que actualizar la pagina para volver a intentarlo 
-      // passwordCheckin.innerHTML += "";
-      // passwordRepeat.innerHTML += "";
+      passwordCheckin.value = "";
+      passwordRepeat.value = "";
     }
   });
 

--- a/src/assets/views/screenLogin.js
+++ b/src/assets/views/screenLogin.js
@@ -25,7 +25,7 @@ export const screenLogin = () => {
           <button type="button" id="buttonGoogle" value="Iniciar sesión con Google">Iniciar sesión con Google</button>
                     
           <!-- boton para registro de nuevos usuarios -->
-          <button type="button" id="btn-checkin1">Registrarse</button>
+          <button type="button" id="btn-checkin1">Registrate</button>
       </form>
     </div>
       `;


### PR DESCRIPTION
Se modifica el tamaño del logo en las diferentes vistas por sugerencia de UX (se veía muy alargado)
Soluciono error del registro, no estaba tomando el valor del password y no hacia el registro. 
Se limpian los campos de contraseña si es que estas no coinciden y envía error